### PR TITLE
Add timezone note to Cron node

### DIFF
--- a/packages/nodes-base/nodes/Cron.node.ts
+++ b/packages/nodes-base/nodes/Cron.node.ts
@@ -24,7 +24,7 @@ export class Cron implements INodeType {
 		icon: 'fa:calendar',
 		group: ['trigger'],
 		version: 1,
-		description: 'Triggers the workflow at a specific time',
+		description: 'Triggers the workflow at a specific time. Note: cron execution times depend on timezone configured in workflow settings.',
 		defaults: {
 			name: 'Cron',
 			color: '#00FF00',


### PR DESCRIPTION
Took me half an hour to figure out that corn depends on workflow timezone (and that there's such a thing as workflow timezone). This might save someone 30 mins of debugging. Reject if there's a better way to do this.